### PR TITLE
Set ircserver.ServerPrefix in test

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/robustirc/robustirc/types"
 
 	"github.com/hashicorp/raft"
+	"github.com/sorcix/irc"
 )
 
 func appendLog(logs []*raft.Log, msg string) []*raft.Log {
@@ -42,6 +43,7 @@ func verifyEndState(t *testing.T) {
 
 func TestCompaction(t *testing.T) {
 	ircserver.ClearState()
+	ircserver.ServerPrefix = &irc.Prefix{Name: "testnetwork"}
 
 	tempdir, err := ioutil.TempDir("", "robust-test-")
 	if err != nil {


### PR DESCRIPTION
This fixes a nil-pointer dereference when running go test.
