### PR TITLE
don’t fail the /join HTTP request when the peer is already known

### DIFF
--- a/api.go
+++ b/api.go
@@ -170,7 +170,7 @@ func handleJoin(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("Adding peer %q to the network.\n", req.Addr)
 
-	if err := node.AddPeer(&dnsAddr{req.Addr}).Error(); err != nil {
+	if err := node.AddPeer(&dnsAddr{req.Addr}).Error(); err != nil && err != raft.ErrKnownPeer {
 		log.Println("Could not add peer:", err)
 		http.Error(w, "Could not add peer", 500)
 		return


### PR DESCRIPTION
This means people can just leave their -join parameter present after
bootstrapping the network, which is a nicer failure mode, i think (even
though it’s still not recommended, since you’d need to ensure that
parameter is valid at all times, which is an unnecessary hassle).
