### PR TITLE
bugfix: update lowIndex in DeleteRange()

### DIFF
--- a/raft_logstore/raft_logstore.go
+++ b/raft_logstore/raft_logstore.go
@@ -147,6 +147,7 @@ func (s *RobustLogStore) DeleteRange(min, max uint64) error {
 			return err
 		}
 	}
+	s.lowIndex = max + 1
 	return nil
 }
 


### PR DESCRIPTION
Otherwise the second log compaction will fail because it tries to delete
log entries that were already deleted.
