### PR TITLE
Store each session’s ircPrefix instead of recreating.

### DIFF
--- a/ircserver/ircserver_test.go
+++ b/ircserver/ircserver_test.go
@@ -149,7 +149,7 @@ func TestInvalidChannelPlumbing(t *testing.T) {
 	got := ProcessMessage(id, irc.ParseMessage("JOIN #foobar"))
 	want := []irc.Message{
 		irc.Message{
-			Prefix:   s.ircPrefix(),
+			Prefix:   &s.ircPrefix,
 			Command:  irc.JOIN,
 			Trailing: "#foobar",
 		},


### PR DESCRIPTION
This avoids creating new objects when it’s not necessary.
