### PR TITLE
implement OPER and KILL

### DIFF
--- a/ircserver/ircserver.go
+++ b/ircserver/ircserver.go
@@ -55,6 +55,9 @@ var (
 	newMessage  = sync.NewCond(&sync.Mutex{})
 
 	lastProcessed types.RobustId
+
+	// TODO(secure): remove this once OPER uses custom (configured) passwords.
+	NetworkPassword string
 )
 
 type Session struct {
@@ -63,6 +66,7 @@ type Session struct {
 	Nick         string
 	Channels     map[string]bool
 	LastActivity time.Time
+	Operator     bool
 
 	// The current IRC message id at the time when the session was started.
 	// This is used in handleGetMessages to skip uninteresting messages.
@@ -178,7 +182,8 @@ func ProcessMessage(session types.RobustId, message *irc.Message) []irc.Message 
 		return replies
 	}
 
-	switch message.Command {
+MessageSwitch:
+	switch strings.ToUpper(message.Command) {
 	case irc.NICK:
 		oldPrefix := s.ircPrefix()
 		if len(message.Params) < 1 {
@@ -435,6 +440,80 @@ func ProcessMessage(session types.RobustId, message *irc.Message) []irc.Message 
 			Command:  irc.RPL_ENDOFWHO,
 			Params:   []string{s.Nick, channel},
 			Trailing: "End of /WHO list",
+		})
+
+	case irc.OPER:
+		if len(message.Params) < 2 {
+			replies = append(replies, irc.Message{
+				Prefix:   ServerPrefix,
+				Command:  irc.ERR_NEEDMOREPARAMS,
+				Params:   []string{s.Nick, message.Command},
+				Trailing: "Not enough parameters",
+			})
+			break
+		}
+
+		// TODO(secure): implement restriction to certain hosts once we have a
+		// configuration file. (ERR_NOOPERHOST)
+
+		if message.Params[1] != NetworkPassword {
+			replies = append(replies, irc.Message{
+				Prefix:   ServerPrefix,
+				Command:  irc.ERR_PASSWDMISMATCH,
+				Params:   []string{s.Nick},
+				Trailing: "Password incorrect",
+			})
+			break
+		}
+
+		s.Operator = true
+
+		replies = append(replies, irc.Message{
+			Prefix:   ServerPrefix,
+			Command:  irc.RPL_YOUREOPER,
+			Params:   []string{s.Nick},
+			Trailing: "You are now an IRC operator",
+		})
+
+	case irc.KILL:
+		if len(message.Params) < 1 || strings.TrimSpace(message.Trailing) == "" {
+			replies = append(replies, irc.Message{
+				Prefix:   ServerPrefix,
+				Command:  irc.ERR_NEEDMOREPARAMS,
+				Params:   []string{s.Nick, message.Command},
+				Trailing: "Not enough parameters",
+			})
+			break
+		}
+		if !s.Operator {
+			replies = append(replies, irc.Message{
+				Prefix:   ServerPrefix,
+				Command:  irc.ERR_NOPRIVILEGES,
+				Params:   []string{s.Nick},
+				Trailing: "Permission Denied - You're not an IRC operator",
+			})
+			break
+		}
+
+		for _, session := range Sessions {
+			if NickToLower(session.Nick) != NickToLower(message.Params[0]) {
+				continue
+			}
+
+			replies = append(replies, irc.Message{
+				Prefix:   &session.ircPrefix,
+				Command:  irc.QUIT,
+				Trailing: "Killed by " + s.Nick + ": " + message.Trailing,
+			})
+			DeleteSession(session.Id)
+			break MessageSwitch
+		}
+
+		replies = append(replies, irc.Message{
+			Prefix:   ServerPrefix,
+			Command:  irc.ERR_NOSUCHNICK,
+			Params:   []string{s.Nick, message.Params[0]},
+			Trailing: "No such nick/channel",
 		})
 	}
 

--- a/ircserver/ircserver_test.go
+++ b/ircserver/ircserver_test.go
@@ -194,3 +194,78 @@ func TestInvalidPrivmsg(t *testing.T) {
 		t.Fatalf("got %v, want %v", got, want)
 	}
 }
+
+func TestKill(t *testing.T) {
+	var got, want []irc.Message
+
+	ClearState()
+	NetworkPassword = "foo"
+	ServerPrefix = &irc.Prefix{Name: "robustirc.net"}
+
+	idSecure := types.RobustId{Id: 1420228218166687917}
+	idMero := types.RobustId{Id: 1420228218166687918}
+
+	CreateSession(idSecure, "auth-secure")
+	CreateSession(idMero, "auth-mero")
+
+	got = ProcessMessage(idSecure, irc.ParseMessage("NICK s[E]CuRE"))
+	if len(got) > 0 {
+		for _, msg := range got {
+			if msg.Command != irc.ERR_NICKNAMEINUSE {
+				continue
+			}
+			t.Fatalf("got %v, wanted anything but ERR_NICKNAMEINUSE", msg)
+		}
+	}
+	got = ProcessMessage(idMero, irc.ParseMessage("NICK mero"))
+	want = []irc.Message{*irc.ParseMessage(":robustirc.net 001 mero :Welcome to RobustIRC!")}
+	if len(got) < 1 || bytes.Compare(got[0].Bytes(), want[0].Bytes()) != 0 {
+		t.Fatalf("got %v, want %v", got[0], want[0])
+	}
+
+	got = ProcessMessage(idMero, irc.ParseMessage("KILL secure"))
+	want = []irc.Message{*irc.ParseMessage(":robustirc.net 461 mero KILL :Not enough parameters")}
+	if len(got) != len(want) || len(got) < 1 || bytes.Compare(got[0].Bytes(), want[0].Bytes()) != 0 {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+
+	got = ProcessMessage(idMero, irc.ParseMessage("KILL"))
+	want = []irc.Message{*irc.ParseMessage(":robustirc.net 461 mero KILL :Not enough parameters")}
+	if len(got) != len(want) || len(got) < 1 || bytes.Compare(got[0].Bytes(), want[0].Bytes()) != 0 {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+
+	got = ProcessMessage(idMero, irc.ParseMessage("KILL secure :die"))
+	want = []irc.Message{*irc.ParseMessage(":robustirc.net 481 mero :Permission Denied - You're not an IRC operator")}
+	if len(got) != len(want) || len(got) < 1 || bytes.Compare(got[0].Bytes(), want[0].Bytes()) != 0 {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+
+	got = ProcessMessage(idMero, irc.ParseMessage("OPER mero bar"))
+	want = []irc.Message{*irc.ParseMessage(":robustirc.net 464 mero :Password incorrect")}
+	if len(got) != len(want) || len(got) < 1 || bytes.Compare(got[0].Bytes(), want[0].Bytes()) != 0 {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+
+	got = ProcessMessage(idMero, irc.ParseMessage("OPER mero foo"))
+	want = []irc.Message{*irc.ParseMessage(":robustirc.net 381 mero :You are now an IRC operator")}
+	if len(got) != len(want) || len(got) < 1 || bytes.Compare(got[0].Bytes(), want[0].Bytes()) != 0 {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+
+	got = ProcessMessage(idMero, irc.ParseMessage("KILL socoro :die"))
+	want = []irc.Message{*irc.ParseMessage(":robustirc.net 401 mero socoro :No such nick/channel")}
+	if len(got) != len(want) || len(got) < 1 || bytes.Compare(got[0].Bytes(), want[0].Bytes()) != 0 {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+
+	got = ProcessMessage(idMero, irc.ParseMessage("KILL s[E]CuRE :die now, will you?"))
+	want = []irc.Message{*irc.ParseMessage(":s[E]CuRE!robust@robust/0x13b5aa0a2bcfb8ad QUIT :Killed by mero: die now, will you?")}
+	if len(got) != len(want) || len(got) < 1 || bytes.Compare(got[0].Bytes(), want[0].Bytes()) != 0 {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+
+	if _, err := GetSession(idSecure); err == nil {
+		t.Fatalf("GetSession(%v) returned a session after KILL", idSecure)
+	}
+}

--- a/robustirc.go
+++ b/robustirc.go
@@ -391,6 +391,7 @@ func main() {
 	}
 
 	ircserver.ClearState()
+	ircserver.NetworkPassword = *networkPassword
 
 	transport := NewTransport(&dnsAddr{*peerAddr}, *networkPassword, *tlsCAFile)
 


### PR DESCRIPTION
fixes #14

I’m aware that the test code (and ircserver’s `ProcessMessage` as well) have lots of repetition. I’ll try to clean that up in a subsequent commit.
