### PR TITLE
add /version and /quit handlers

### DIFF
--- a/api.go
+++ b/api.go
@@ -364,8 +364,8 @@ func handleLeader(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func handleVersion(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte(version))
+func handleHash(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(executablehash))
 }
 
 func handleQuit(w http.ResponseWriter, r *http.Request) {

--- a/robustirc.go
+++ b/robustirc.go
@@ -84,7 +84,7 @@ var (
 	peerStore *raft.JSONPeers
 	logStore  *raft_store.LevelDBStore
 
-	version string = executableHash()
+	executablehash string = executableHash()
 )
 
 type robustSnapshot struct {
@@ -475,7 +475,7 @@ func main() {
 	privaterouter.HandleFunc("/join", handleJoin)
 	privaterouter.HandleFunc("/snapshot", handleSnapshot)
 	privaterouter.HandleFunc("/leader", handleLeader)
-	privaterouter.HandleFunc("/version", handleVersion)
+	privaterouter.HandleFunc("/executablehash", handleHash)
 	privaterouter.HandleFunc("/quit", handleQuit)
 
 	publicrouter := mux.NewRouter()


### PR DESCRIPTION
/version returns the hex representation of the sha256 hash sum of the
running binary.

/quit calls log.Fatal, expecting to be restarted by e.g. systemd.
