### PR TITLE
implement the AWAY IRC command

### DIFF
--- a/ircserver/ircserver.go
+++ b/ircserver/ircserver.go
@@ -81,6 +81,7 @@ type Session struct {
 	Channels     map[string]bool
 	LastActivity time.Time
 	Operator     bool
+	AwayMsg      string
 
 	// The current IRC message id at the time when the session was started.
 	// This is used in handleGetMessages to skip uninteresting messages.


### PR DESCRIPTION
Filed #51 for making the test simpler.

Added a TODO for using a map for quicker nickname lookup.

Didn’t want to do these in this PR because this one is about the AWAY command itself.
