### PR TITLE
Bugfix: persist messages to an IRC log instead of abusing the raft log

### DIFF
--- a/status.go
+++ b/status.go
@@ -18,13 +18,13 @@ import (
 func handleStatus(res http.ResponseWriter, req *http.Request) {
 	p, _ := peerStore.Peers()
 
-	lo, err := logStore.FirstIndex()
+	lo, err := ircStore.FirstIndex()
 	if err != nil {
 		log.Printf("Could not get first index: %v", err)
 		http.Error(res, "internal error", 500)
 		return
 	}
-	hi, err := logStore.LastIndex()
+	hi, err := ircStore.LastIndex()
 	if err != nil {
 		log.Printf("Could not get last index: %v", err)
 		http.Error(res, "internal error", 500)
@@ -36,7 +36,7 @@ func handleStatus(res http.ResponseWriter, req *http.Request) {
 		for i := lo; i <= hi; i++ {
 			l := new(raft.Log)
 
-			if err := logStore.GetLog(i, l); err != nil {
+			if err := ircStore.GetLog(i, l); err != nil {
 				log.Printf("Could not get entry %d: %v", i, err)
 				http.Error(res, "internal error", 500)
 				return
@@ -100,12 +100,12 @@ func handleIrclog(w http.ResponseWriter, r *http.Request) {
 	// better way that is lighter on resources. Perhaps store the processed
 	// indexes in the session?
 	inputs := make(map[types.RobustId]*types.RobustMessage)
-	first, _ := logStore.FirstIndex()
-	last, _ := logStore.LastIndex()
+	first, _ := ircStore.FirstIndex()
+	last, _ := ircStore.LastIndex()
 	for idx := first; idx <= last; idx++ {
 		var elog raft.Log
 
-		if err := logStore.GetLog(idx, &elog); err != nil {
+		if err := ircStore.GetLog(idx, &elog); err != nil {
 			http.Error(w, fmt.Sprintf("Cannot read log: %v", err), http.StatusInternalServerError)
 			return
 		}

--- a/status.html
+++ b/status.html
@@ -103,7 +103,7 @@
 			</div>
 
 			<div class="row">
-				<h2>Raft Log Entries (index={{ .First }} to index={{ .Last}})</h2>
+				<h2>IRC Log Entries (index={{ .First }} to index={{ .Last}})</h2>
 				<table class="table table-striped">
 					<thead>
 						<tr>


### PR DESCRIPTION
Previously, we have directly used the raft log when creating snapshots
and (more importantly) restoring snapshots.

This broke recovery when restarting from disk, because raft’s
last_log_index is set before restoring the snapshot, but in
fsm.Restore(), we deleted the entire raft log, meaning that
last_log_index was pointing to a no longer existing log index.

Instead, we now use a separate IRC log LevelDB instance to which
messages are persisted.
