### PR TITLE
Keep username and realname from USER messages after all.

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -65,12 +65,13 @@ func TestCompaction(t *testing.T) {
 	var logs []*raft.Log
 	logs = appendLog(logs, `{"Id": {"Id": 1}, "Type": 0, "Data": "auth"}`)
 	logs = appendLog(logs, `{"Id": {"Id": 2}, "Session": {"Id": 1}, "Type": 2, "Data": "NICK sECuRE"}`)
-	logs = appendLog(logs, `{"Id": {"Id": 3}, "Session": {"Id": 1}, "Type": 2, "Data": "NICK secure_"}`)
-	logs = appendLog(logs, `{"Id": {"Id": 4}, "Session": {"Id": 1}, "Type": 2, "Data": "JOIN #chaos-hd"}`)
-	logs = appendLog(logs, `{"Id": {"Id": 5}, "Session": {"Id": 1}, "Type": 2, "Data": "JOIN #i3"}`)
-	logs = appendLog(logs, `{"Id": {"Id": 6}, "Session": {"Id": 1}, "Type": 2, "Data": "PRIVMSG #chaos-hd :heya"}`)
-	logs = appendLog(logs, `{"Id": {"Id": 7}, "Session": {"Id": 1}, "Type": 2, "Data": "PRIVMSG #chaos-hd :newer message"}`)
-	logs = appendLog(logs, `{"Id": {"Id": 8}, "Session": {"Id": 1}, "Type": 2, "Data": "PART #i3"}`)
+	logs = appendLog(logs, `{"Id": {"Id": 3}, "Session": {"Id": 1}, "Type": 2, "Data": "USER blah 0 * :Michael Stapelberg"}`)
+	logs = appendLog(logs, `{"Id": {"Id": 4}, "Session": {"Id": 1}, "Type": 2, "Data": "NICK secure_"}`)
+	logs = appendLog(logs, `{"Id": {"Id": 5}, "Session": {"Id": 1}, "Type": 2, "Data": "JOIN #chaos-hd"}`)
+	logs = appendLog(logs, `{"Id": {"Id": 6}, "Session": {"Id": 1}, "Type": 2, "Data": "JOIN #i3"}`)
+	logs = appendLog(logs, `{"Id": {"Id": 7}, "Session": {"Id": 1}, "Type": 2, "Data": "PRIVMSG #chaos-hd :heya"}`)
+	logs = appendLog(logs, `{"Id": {"Id": 8}, "Session": {"Id": 1}, "Type": 2, "Data": "PRIVMSG #chaos-hd :newer message"}`)
+	logs = appendLog(logs, `{"Id": {"Id": 9}, "Session": {"Id": 1}, "Type": 2, "Data": "PART #i3"}`)
 
 	// These messages are too new to be compacted.
 	nowId := time.Now().UnixNano()

--- a/ircserver/commands.go
+++ b/ircserver/commands.go
@@ -158,7 +158,11 @@ func cmdNick(s *Session, msg *irc.Message) []*irc.Message {
 }
 
 func cmdUser(s *Session, msg *irc.Message) []*irc.Message {
-	// We don’t need any information from the USER message.
+	// We keep the username (so that bans are more effective) and realname
+	// (some people actually set it and look at it).
+	s.Username = msg.Params[0]
+	s.Realname = msg.Trailing
+	s.updateIrcPrefix()
 	return []*irc.Message{}
 }
 

--- a/robustirc.go
+++ b/robustirc.go
@@ -122,7 +122,6 @@ func (s *robustSnapshot) Persist(sink raft.SnapshotSink) error {
 				// TODO: MODE (tricky)
 				// Delete messages which don’t modify state.
 				if ircmsg.Command == irc.PRIVMSG ||
-					ircmsg.Command == irc.USER ||
 					ircmsg.Command == irc.WHO ||
 					ircmsg.Command == irc.QUIT {
 					continue


### PR DESCRIPTION
This might come in handy for bans, and some humans actually look at the
real names.
