### PR TITLE
copy logs to glog so that we have reliable logs

### DIFF
--- a/cmd/robustirc-localnet/localnet.go
+++ b/cmd/robustirc-localnet/localnet.go
@@ -115,6 +115,7 @@ func startircserver(singlenode bool) {
 		log.Fatal(err)
 	}
 	args = append(args, "-raftdir="+tempdir)
+	args = append(args, "-log_dir="+tempdir)
 	if err := recordResource("tempdir", tempdir); err != nil {
 		log.Panicf("Could not record tempdir: %v", err)
 	}

--- a/robustirc.go
+++ b/robustirc.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/hashicorp/raft"
 	"github.com/sorcix/irc"
+	"github.com/stapelberg/glog"
 
 	_ "net/http/pprof"
 )
@@ -451,6 +452,10 @@ func main() {
 	}
 	flag.Parse()
 
+	defer glog.Flush()
+	glog.MaxSize = 64 * 1024 * 1024
+	glog.CopyStandardLogTo("INFO")
+
 	if *version {
 		log.Printf("RobustIRC %s\n", Version)
 		return
@@ -488,6 +493,7 @@ func main() {
 	var p []net.Addr
 
 	config := raft.DefaultConfig()
+	config.Logger = log.New(glog.LogBridgeFor("INFO"), "", log.Lshortfile)
 	if *singleNode {
 		config.EnableSingleNode = true
 	}


### PR DESCRIPTION
journald’s default settings make it drop messages when we send too many.
