### PR TITLE
Create raftDir if it does not exist

### DIFF
--- a/robustirc.go
+++ b/robustirc.go
@@ -343,6 +343,10 @@ func main() {
 		return
 	}
 
+	if err := os.MkdirAll(*raftDir, 0700); err != nil {
+		log.Fatal(err)
+	}
+
 	if _, err := os.Stat(filepath.Join(*raftDir, "deletestate")); err == nil {
 		if err := os.RemoveAll(*raftDir); err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
In deployments where the container platform makes prepopulating empty directories a pain it helps if we have the server create the directory itself. This change either creates raftDir if it doesn't exist or does nothing. 